### PR TITLE
Creates and test optional query of comment_count on  the endpoint GET /api/articles/:article_id, used for retrieving the comment count for a specific article

### DIFF
--- a/__tests__/app.test.js
+++ b/__tests__/app.test.js
@@ -71,21 +71,36 @@ describe("GET /api/articles/:article_id", () => {
       .get("/api/articles/1")
       .expect(200)
       .then(({ body }) => {
-        expect(body.length).toBeGreaterThan(0);
-        expect(body).toBeSortedBy("date", { descending: true });
-        expect(body).toMatchObject([
-          {
-            article_id: 1,
-            title: "Living in the shadow of a great man",
-            topic: "mitch",
-            author: "butter_bridge",
-            body: "I find this existence challenging",
-            created_at: expect.any(String),
-            votes: 100,
-            article_img_url:
-              "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
-          },
-        ]);
+        expect(Object.keys(body).length).toBeGreaterThan(0);
+        expect(body).toMatchObject({
+          article_id: 1,
+          title: "Living in the shadow of a great man",
+          topic: "mitch",
+          author: "butter_bridge",
+          body: "I find this existence challenging",
+          created_at: expect.any(String),
+          votes: 100,
+          article_img_url:
+            "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700",
+        });
+      });
+  });
+  test("GET:200 - Responds with the comment_count of a specific article when passed a query of comment_count", () => {
+    return request(app)
+      .get("/api/articles/1?comment_count=true")
+      .expect(200)
+      .then(({ body }) => {
+        expect(body).toMatchObject({
+          comment_count: 11,
+        });
+      });
+  });
+  test("GET:400 - Responds with an error message of Incorrect query value if the comment_count query is neither true or false", () => {
+    return request(app)
+      .get("/api/articles/1?comment_count=yes")
+      .expect(400)
+      .then(({ body }) => {
+        expect(body.msg).toBe("Incorrect query value");
       });
   });
   test("GET:404 - Responds with an error message of author id invalid if the author Id does not exist", () => {

--- a/app/app.controller.js
+++ b/app/app.controller.js
@@ -33,7 +33,8 @@ exports.getAllEndpoints = (req, res, next) => {
 
 exports.getArticleById = (req, res, next) => {
   const { article_id } = req.params;
-  selectArticleById(article_id)
+  const { comment_count } = req.query;
+  selectArticleById(article_id, comment_count)
     .then((article) => {
       res.status(200).send(article);
     })
@@ -44,7 +45,6 @@ exports.getArticleById = (req, res, next) => {
 
 exports.getAllArticles = (req, res, next) => {
   const { topic } = req.query;
-  console.log(topic, "In the controller");
   selectAllArticles(topic)
     .then((articles) => {
       res.status(200).send(articles);

--- a/app/app.model.js
+++ b/app/app.model.js
@@ -18,17 +18,31 @@ exports.readEndpoints = () => {
     });
 };
 
-exports.selectArticleById = (article_id) => {
+exports.selectArticleById = (article_id, comment_count) => {
+  const validCommentCount = ["true", "false"];
+
+  let query = "SELECT ";
+
   if (/^[0-9]+$/.test(article_id) === false) {
     return Promise.reject({ status: 400, msg: "Incorrect id type" });
   }
-  let query = "SELECT * FROM articles WHERE article_id = $1 ;";
+
+  if (comment_count && !validCommentCount.includes(comment_count)) {
+    return Promise.reject({ status: 400, msg: "Incorrect query value" });
+  }
+
+  if (comment_count) {
+    query += "COUNT(comments.comment_id)::INT AS comment_count FROM comments ";
+  } else {
+    query += "* FROM articles ";
+  }
+  query += "WHERE article_id = $1 ;";
 
   return db.query(query, [article_id]).then((article) => {
     if (article.rows.length === 0) {
       return Promise.reject({ status: 404, msg: "Author id not found" });
     }
-    return article.rows;
+    return article.rows[0];
   });
 };
 


### PR DESCRIPTION
- Changed controller function getArticleById which now retrieves the comment_count query and passes this along with the article_id to the model function
- Model function amended to pragmatically build the psql query by checking for a valid comment_count query, and if comment_count is present it queries the comments table with the relevant article_id , otherwise it queries the articles table to retrieve article by id
- Response is sent back to the controller which sends the status code and response to the client
- Tests for format of comment_count response object and incorrect query value